### PR TITLE
Add a Binder badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     <a href='http://hulk.readthedocs.io/en/latest/?badge=latest'><img src='https://readthedocs.org/projects/hulk/badge/?version=latest' alt='Documentation Status' /></a>
     <a href="https://goreportcard.com/report/github.com/will-rowe/hulk"><img src="https://goreportcard.com/badge/github.com/will-rowe/hulk" alt="reportcard"></a>
     <a href="https://zenodo.org/badge/latestdoi/143890875"><img src="https://zenodo.org/badge/143890875.svg" alt="DOI"></a>
+    <a href="https://mybinder.org/v2/gh/will-rowe/hulk/master?filepath=paper%2Fanalysis-notebooks"><img src="https://mybinder.org/badge_logo.svg" alt="Binder"></a>
 </div>
 
 ***

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,8 +4,10 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python
+  - python==3.6.5
   - hulk==0.0.2
   - pandas==0.23.4
-  - seaborn==0.8.0
+  - seaborn==0.9.0
   - scikit-learn==0.19.2
+  - simka==1.4.0
+  - sra-tools==2.9.1_1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - hulk==0.0.2
   - pandas==0.23.4
   - seaborn==0.8.0
-  - scikit-learn==0.20.0
+  - scikit-learn==0.19.2

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,11 @@
+name: hulk
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python
+  - hulk==0.0.2
+  - pandas==0.23.4
+  - seaborn==0.8.0
+  - scikit-learn==0.20.0


### PR DESCRIPTION
Hi!

I added a badge for running Binder for the paper notebooks, and also an `environment.yml` file with the dependencies. I kept scikit-learn in version 0.19.2 because the random forest classification example breaks on 0.20 (because cross_val_score was [moved to another module](https://scikit-learn.org/0.19/modules/generated/sklearn.cross_validation.cross_val_score.html))

Here is a temporary link pointing to my branch while it is not merged: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/luizirber/hulk/binder?filepath=paper%2Fanalysis-notebooks)